### PR TITLE
DC:Creator now point from publication to author

### DIFF
--- a/CeurWsParser/parsers/proceedings_parser.py
+++ b/CeurWsParser/parsers/proceedings_parser.py
@@ -64,7 +64,7 @@ class ProceedingsSummaryParser(Parser):
                 triples.append((agent, RDF.type, FOAF.Agent))
                 triples.append((agent, FOAF.name, Literal(editor, datatype=XSD.string)))
                 triples.append((resource, SWRC.editor, agent))
-                triples.append((agent, DC.creator, resource))
+                triples.append((resource, DC.creator, agent))
 
         self.write_triples(triples)
 

--- a/CeurWsParser/parsers/publication_parser.py
+++ b/CeurWsParser/parsers/publication_parser.py
@@ -66,7 +66,7 @@ class PublicationParser(Parser):
                 agent = URIRef(config.id['person'] + urllib.quote(editor.encode('utf-8')))
                 triples.append((agent, RDF.type, FOAF.Agent))
                 triples.append((agent, FOAF.name, Literal(editor, datatype=XSD.string)))
-                triples.append((agent, DC.creator, resource))
+                triples.append((resource, DC.creator, agent))
             if 'presentedAt' in publication and len(publication['presentedAt']) > 0:
                 for w in publication['presentedAt']:
                     triples.append((resource, BIBO.presentedAt, w))


### PR DESCRIPTION
We are preparing the data for the 2015th semantic publishing challenge. We are now extracting LOD from all CEUR-WS.org workshops using your tool and found that this property was used in the wrong direction. We fixed it in the sources, but not yet in the test queries.

I am Sahar, working with Christoph (who will also send you an email in a few minutes).
http://eis.iai.uni-bonn.de/SaharVahdati.html
